### PR TITLE
Use grep without -P (Perl) flag

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -209,7 +209,7 @@ gunzip \$tmpdir/primary.xml.gz
 
 for pkg in \$ZYPPER_PACKAGES; do
 	# This is pretty ugly
-	pkg_path=\$(grep -oP "core\/.*\/\$pkg-[0-9\.\-\_]+\.(?:(?!src).)*\.rpm" \$tmpdir/primary.xml)
+	pkg_path=\$(grep -oE "core\/.*\/\$pkg-[0-9\.\-\_]+.*\.rpm" \$tmpdir/primary.xml | grep -v "\/src\/")
 	curl -L \$JOLLA_REPO/\$pkg_path > \$tmpdir/\$pkg.rpm
 done
 


### PR DESCRIPTION
When patching 3.2.0.8, busybox grep is used, and it doesn't support Perl regular expressions. Negative lookahead is probably difficult to do without that, so rewrite as two grep expressions, the second to filter out /src/ paths. 3.0.1.11 worked fine, so it's probably new in 3.2.0.8.