### PR TITLE
optionally disable now-forced home encryption

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -22,6 +22,7 @@ ATRUNCATE_PATH="${PATCHER_DIR}/atruncate.py"
 #REPACK_SCRIPT="${PATCHER_DIR}/droid-config-f5121/kickstart/pack/f5121/hybris"
 #PACKAGE="pattern:droid-compat-f5321"
 #REPOSITORY_URI="http://repo.merproject.org/obs/home:/eugenio:/compat-f5321/sailfish_latest_armv7hl/"
+DISABLE_HOME_ENCRYPTION_AT_BOOT="no"
 
 info() {
 	echo "I: $@"
@@ -253,6 +254,12 @@ if [ "$PATCH_KERNEL" == "yes" ]; then
 	rpm-divert unapply --package droid-compat-tmp
 
 	rpm-divert remove droid-compat-tmp /usr/sbin/flash-partition
+fi
+
+
+### encryption is mandatory starting in 3.4
+if [ "$DISABLE_HOME_ENCRYPTION_AT_BOOT" == "yes" ]; then
+  rm /var/lib/sailfish-device-encryption/encrypt-home
 fi
 
 # Terminate what we started


### PR DESCRIPTION
SFOS 3.4 made this buggy 5-digit "security" feature mandatory! :( :( :(
honestly youre lucky to be out of this mess...

feel free to never merge this, or perhaps to comment it out by default, but i imagine the sort of people that rely on this repo probably dont like having important config options removed, and its easy to encrypt in settings afterwards.

i tested the patch on 3.4 and 3.3, and tried re-encrypting afterward on 3.4 in settings, and everything seems to work.

(oh and if you do see this, thanks again for all the great support all this time)