### PR TITLE
fixes for kvarken (rpm HACK 1.2.4.jolla => 1.2.6.jolla, VALID_PRODUCTS in flash.sh)

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -157,6 +157,10 @@ mkdir -p patcher-tmp/work/fimage
 mkdir -p patcher-tmp/work/tree
 mkdir -p patcher-result
 
+### add f5321 to VALID_PRODUCTS for flash.sh
+sed -i 's/"F5121"/"F5121"\n"F5321"/' flash-config.sh
+###
+
 FIMAGE_MPOINT="$(mktemp -d -p ${BASE_TEMP_DIR})"
 ROOT_MPOINT="$(mktemp -d -p ${BASE_TEMP_DIR})"
 

--- a/patch.sh
+++ b/patch.sh
@@ -218,6 +218,15 @@ for pkg in \$ZYPPER_PACKAGES; do
 	# This is pretty ugly
 	pkg_path=\$(grep -oE "(core|oss)\/.*\/\$pkg-[0-9\.\-\_]+.*\.rpm" \$tmpdir/primary.xml | grep -v "\/src\/")
 	curl -L \$JOLLA_REPO/\$pkg_path > \$tmpdir/\$pkg.rpm
+
+  ### HACK ###
+  if grep '<head><title>404 Not Found</title></head>' \$tmpdir/\$pkg.rpm; then
+    hack_pkg_path=\$(echo \$pkg_path | sed s/1\\.2\\.4\\.jolla/1.2.6.jolla/)
+    echo "HACK PKG PATH: \$pkg_path => \$hack_pkg_path"
+    curl -L \$JOLLA_REPO/\$hack_pkg_path > \$tmpdir/\$pkg.rpm
+  fi
+  ### HACK ###
+
 done
 
 # This is pretty ugly


### PR DESCRIPTION
primary.xml is just wrong for kvarken i guess? i dont actually know whats failing where, but the rpm versions fetched for kvarken just dont exist.

without this hack, i get the old:
`error: open of <html> failed: No such file or directory`
(from the rpm cmd, since curl fetches a 404 html error page)

with this hack, i print 3 times:
`HACK PKG PATH: oss/armv7hl/augeas-libs-1.12.0+git2-1.2.4.jolla.armv7hl.rpm => oss/armv7hl/augeas-libs-1.12.0+git2-1.2.6.jolla.armv7hl.rpm`